### PR TITLE
Update to netstandard2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 obj/
+.vs/
 .vscode/
 .idea/
 codeship.aes

--- a/Botwin.sln
+++ b/Botwin.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Botwin", "src\Botwin.csproj", "{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Botwin", "src\Botwin.csproj", "{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BotwinSample", "samples\BotwinSample.csproj", "{2C511F74-490A-4804-A826-DC9626C669E9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BotwinSample", "samples\BotwinSample.csproj", "{2C511F74-490A-4804-A826-DC9626C669E9}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{5D056A8A-821C-4C3C-A281-4FA7F8CE251B}"
 EndProject
@@ -13,7 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{35DE
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{DCB5B9A0-F06D-4BDF-917D-A459C790C718}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Botwin.Tests", "test\Botwin.Tests.csproj", "{32E3C950-F6C1-4635-B87F-0EA30044E2F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Botwin.Tests", "test\Botwin.Tests.csproj", "{32E3C950-F6C1-4635-B87F-0EA30044E2F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,50 +24,53 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|x64.ActiveCfg = Debug|x64
-		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|x64.Build.0 = Debug|x64
-		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|x86.ActiveCfg = Debug|x86
-		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|x86.Build.0 = Debug|x86
+		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|x64.Build.0 = Debug|Any CPU
+		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Debug|x86.Build.0 = Debug|Any CPU
 		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|x64.ActiveCfg = Release|x64
-		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|x64.Build.0 = Release|x64
-		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|x86.ActiveCfg = Release|x86
-		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|x86.Build.0 = Release|x86
+		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|x64.ActiveCfg = Release|Any CPU
+		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|x64.Build.0 = Release|Any CPU
+		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|x86.ActiveCfg = Release|Any CPU
+		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}.Release|x86.Build.0 = Release|Any CPU
 		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|x64.ActiveCfg = Debug|x64
-		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|x64.Build.0 = Debug|x64
-		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|x86.ActiveCfg = Debug|x86
-		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|x86.Build.0 = Debug|x86
+		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C511F74-490A-4804-A826-DC9626C669E9}.Debug|x86.Build.0 = Debug|Any CPU
 		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|x64.ActiveCfg = Release|x64
-		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|x64.Build.0 = Release|x64
-		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|x86.ActiveCfg = Release|x86
-		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|x86.Build.0 = Release|x86
+		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|x64.Build.0 = Release|Any CPU
+		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C511F74-490A-4804-A826-DC9626C669E9}.Release|x86.Build.0 = Release|Any CPU
 		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|x64.ActiveCfg = Debug|x64
-		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|x64.Build.0 = Debug|x64
-		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|x86.ActiveCfg = Debug|x86
-		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|x86.Build.0 = Debug|x86
+		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|x64.Build.0 = Debug|Any CPU
+		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Debug|x86.Build.0 = Debug|Any CPU
 		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|x64.ActiveCfg = Release|x64
-		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|x64.Build.0 = Release|x64
-		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|x86.ActiveCfg = Release|x86
-		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|x86.Build.0 = Release|x86
+		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|x64.ActiveCfg = Release|Any CPU
+		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|x64.Build.0 = Release|Any CPU
+		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|x86.ActiveCfg = Release|Any CPU
+		{32E3C950-F6C1-4635-B87F-0EA30044E2F4}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A6D020CF-1722-4AB3-A8B3-69F54319AD6A} = {5D056A8A-821C-4C3C-A281-4FA7F8CE251B}
 		{2C511F74-490A-4804-A826-DC9626C669E9} = {35DE35A0-758D-4FDD-BDA3-67F04F65677D}
 		{32E3C950-F6C1-4635-B87F-0EA30044E2F4} = {DCB5B9A0-F06D-4BDF-917D-A459C790C718}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9096DE78-6327-48BA-AE0E-336F769681A7}
 	EndGlobalSection
 EndGlobal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-preview1-sdk
+FROM microsoft/dotnet:2.0.0-sdk
 
 COPY . /code
 

--- a/samples/BotwinSample.csproj
+++ b/samples/BotwinSample.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../src/Botwin.csproj" />

--- a/src/Botwin.csproj
+++ b/src/Botwin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Authors>Jonathan Channon</Authors>
     <Description>Botwin is a library that allows Nancy-esque routing for use with ASP.Net Core.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="6.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-    <PackageReference Include="microsoft.extensions.dependencyinjection" Version="2.0.0-preview1-final" />
+    <PackageReference Include="microsoft.extensions.dependencyinjection" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Botwin.csproj
+++ b/src/Botwin.csproj
@@ -13,6 +13,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-    <PackageReference Include="microsoft.extensions.dependencyinjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/BotwinExtensions.cs
+++ b/src/BotwinExtensions.cs
@@ -9,6 +9,7 @@ namespace Botwin
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Routing;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
 
     public static class BotwinExtensions
     {
@@ -127,16 +128,12 @@ namespace Botwin
         public static void AddBotwin(this IServiceCollection services)
         {
             //Get IAssemblyProvider, if not found register default provider.
+            services.TryAddSingleton<IAssemblyProvider, AssemblyProvider>();
+
             var provider = services.BuildServiceProvider();
             var assemblyProvider = provider.GetService<IAssemblyProvider>();
-            if (assemblyProvider == null)
-            {
-                services.AddSingleton<IAssemblyProvider, AssemblyProvider>();
-            }
-            assemblyProvider = provider.GetService<IAssemblyProvider>();
 
             services.AddRouting();
-
 
             var modules = assemblyProvider.GetAssembly().GetTypes().Where(t => typeof(BotwinModule).IsAssignableFrom(t) && t != typeof(BotwinModule));
             foreach (var module in modules)

--- a/src/DefaultJsonResponseNegotiator.cs
+++ b/src/DefaultJsonResponseNegotiator.cs
@@ -12,7 +12,7 @@
     {
         public bool CanHandle(IList<MediaTypeHeaderValue> accept)
         {
-            return accept.Any(x => x.MediaType.IndexOf("json", StringComparison.OrdinalIgnoreCase) >= 0);
+            return accept.Any(x => x.MediaType.ToString().IndexOf("json", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         public async Task Handle(HttpRequest req, HttpResponse res, object model)

--- a/test/Botwin.Tests.csproj
+++ b/test/Botwin.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/test/ResponseNegotiatorTests.cs
+++ b/test/ResponseNegotiatorTests.cs
@@ -61,7 +61,7 @@ namespace Botwin.Tests
     {
         public bool CanHandle(IList<MediaTypeHeaderValue> accept)
         {
-            return accept.Any(x => x.MediaType.IndexOf("foo/bar", StringComparison.OrdinalIgnoreCase) >= 0);
+            return accept.Any(x => x.MediaType.ToString().IndexOf("foo/bar", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         public async Task Handle(HttpRequest req, HttpResponse res, object model)


### PR DESCRIPTION
Hi,

Randomly saw your tweet about updating to netstandard2.0 and had been looking for something to get a bit of a look in to dotnetcore, so had a go.

Seems to work alright to me, not sure what VS2017 has done to the .sln though.
Also made what I believe is the change suggested by David Fowler in #13 as without changes it was blowing up due to a null assemblyProvider.

The mediaType check in DefaultJsonResponseNegotiator could probably be more optimal but I didn't see anything after a quick look.

Hope it helps