### PR TITLE
Passing cancellation token into IResponseNegotiator

### DIFF
--- a/src/DefaultJsonResponseNegotiator.cs
+++ b/src/DefaultJsonResponseNegotiator.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Net.Http.Headers;
@@ -15,10 +16,10 @@
             return accept.Any(x => x.MediaType.ToString().IndexOf("json", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
-        public async Task Handle(HttpRequest req, HttpResponse res, object model)
+        public async Task Handle(HttpRequest req, HttpResponse res, object model, CancellationToken cancellationToken)
         {
             res.ContentType = "application/json; charset=utf-8";
-            await res.WriteAsync(JsonConvert.SerializeObject(model));
+            await res.WriteAsync(JsonConvert.SerializeObject(model), cancellationToken);
         }
     }
 }

--- a/src/IResponseNegotiator.cs
+++ b/src/IResponseNegotiator.cs
@@ -1,6 +1,7 @@
 ﻿namespace Botwin
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Net.Http.Headers;
@@ -9,6 +10,6 @@
     {
         bool CanHandle(IList<MediaTypeHeaderValue> accept);
 
-        Task Handle(HttpRequest req, HttpResponse res, object model);
+        Task Handle(HttpRequest req, HttpResponse res, object model, CancellationToken cancellationToken);
     }
 }

--- a/src/Response/ResponseExtensions.cs
+++ b/src/Response/ResponseExtensions.cs
@@ -18,7 +18,7 @@ namespace Botwin.Response
 
             var negotiator = negotiators.FirstOrDefault(x => x.CanHandle(accept)) ?? negotiators.FirstOrDefault(x => x.CanHandle(new List<MediaTypeHeaderValue>() { new MediaTypeHeaderValue("application/json") }));
 
-            await negotiator.Handle(response.HttpContext.Request, response, obj);
+            await negotiator.Handle(response.HttpContext.Request, response, obj, cancellationToken);
         }
 
         public static async Task AsJson(this HttpResponse response, object obj, CancellationToken cancellationToken = default(CancellationToken))
@@ -27,7 +27,7 @@ namespace Botwin.Response
 
             var negotiator = negotiators.FirstOrDefault(x => x.CanHandle(new List<MediaTypeHeaderValue>() { new MediaTypeHeaderValue("application/json") }));
 
-            await negotiator.Handle(response.HttpContext.Request, response, obj);
+            await negotiator.Handle(response.HttpContext.Request, response, obj, cancellationToken);
         }
     }
 }

--- a/test/ResponseNegotiatorTests.cs
+++ b/test/ResponseNegotiatorTests.cs
@@ -5,6 +5,7 @@ namespace Botwin.Tests
     using System.Linq;
     using System.Net.Http;
     using System.Reflection;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
@@ -62,9 +63,9 @@ namespace Botwin.Tests
             return accept.Any(x => x.MediaType.ToString().IndexOf("foo/bar", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
-        public async Task Handle(HttpRequest req, HttpResponse res, object model)
+        public async Task Handle(HttpRequest req, HttpResponse res, object model, CancellationToken cancellationToken = default(CancellationToken))
         {
-            await res.WriteAsync("FOOBAR");
+            await res.WriteAsync("FOOBAR", cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Methods in `ResponseExtensions` had an optional parameter but this wasn't used.  I've added a cancellation token to `IResponseNegotiator.Handle` and passed this into the call to `WriteAsync`.