### PR TITLE
Added RequiresAuthentication & RequiresClaims

### DIFF
--- a/src/BotwinModule.cs
+++ b/src/BotwinModule.cs
@@ -12,7 +12,7 @@ namespace Botwin
 
         private readonly string basePath;
 
-        public Func<HttpContext, Task<bool>> Before { get; protected set; }
+        public Func<HttpContext, Task<bool>> Before { get; set; } 
 
         public RequestDelegate After { get; protected set; }
 

--- a/src/BotwinModuleSecurity.cs
+++ b/src/BotwinModuleSecurity.cs
@@ -12,7 +12,7 @@
         {
             module.Before = context =>
             {
-                var authenticated = context?.User?.Identity != null && context.User.Identity.IsAuthenticated;
+                var authenticated += context?.User?.Identity != null && context.User.Identity.IsAuthenticated;
                 if (!authenticated)
                 {
                     context.Response.StatusCode = 401;

--- a/src/BotwinModuleSecurity.cs
+++ b/src/BotwinModuleSecurity.cs
@@ -10,9 +10,9 @@
     {
         public static void RequiresAuthentication(this BotwinModule module)
         {
-            module.Before = context =>
+            module.Before += context =>
             {
-                var authenticated += context?.User?.Identity != null && context.User.Identity.IsAuthenticated;
+                var authenticated = context?.User?.Identity != null && context.User.Identity.IsAuthenticated;
                 if (!authenticated)
                 {
                     context.Response.StatusCode = 401;

--- a/src/BotwinModuleSecurity.cs
+++ b/src/BotwinModuleSecurity.cs
@@ -1,0 +1,20 @@
+﻿namespace Botwin
+{
+    using System.Threading.Tasks;
+
+    public static class BotwinModuleSecurity
+    {
+        public static void RequiresAuthentication(this BotwinModule module)
+        {
+            module.Before = context =>
+            {
+                var authenticated = context?.User?.Identity != null && context.User.Identity.IsAuthenticated;
+                if (!authenticated)
+                {
+                    context.Response.StatusCode = 401;
+                }
+                return Task.FromResult(authenticated);
+            };
+        }
+    }
+}

--- a/src/BotwinModuleSecurity.cs
+++ b/src/BotwinModuleSecurity.cs
@@ -1,5 +1,9 @@
 ﻿namespace Botwin
 {
+    using System;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using System.Security.Claims;
     using System.Threading.Tasks;
 
     public static class BotwinModuleSecurity
@@ -14,6 +18,20 @@
                     context.Response.StatusCode = 401;
                 }
                 return Task.FromResult(authenticated);
+            };
+        }
+
+        public static void RequiresClaims(this BotwinModule module, params Predicate<Claim>[] claims)
+        {
+            module.RequiresAuthentication();
+            module.Before += context =>
+            {
+                var validClaims = context.User != null && claims.All(context.User.HasClaim);
+                if (!validClaims)
+                {
+                    context.Response.StatusCode = 401;
+                }
+                return Task.FromResult(validClaims);
             };
         }
     }

--- a/test/SecurityClaimsModule.cs
+++ b/test/SecurityClaimsModule.cs
@@ -1,0 +1,15 @@
+﻿namespace Botwin.Tests
+{
+    using System.Security.Claims;
+    using Microsoft.AspNetCore.Http;
+
+    public class SecurityClaimsModule : BotwinModule
+    {
+        public SecurityClaimsModule()
+        {
+            this.RequiresClaims(c => c.Type == ClaimTypes.Actor);
+
+            this.Get("/secureclaim", async (request, response, routeData) => { await response.WriteAsync("secure claim"); });
+        }
+    }
+}

--- a/test/SecurityModule.cs
+++ b/test/SecurityModule.cs
@@ -1,0 +1,17 @@
+﻿namespace Botwin.Tests
+{
+    using Microsoft.AspNetCore.Http;
+
+    public class SecurityModule : BotwinModule
+    {
+        public SecurityModule()
+        {
+            this.RequiresAuthentication();
+            
+            this.Get("/secure", async (request, response, routeData) =>
+            {
+                await response.WriteAsync("secure");
+            });
+        }
+    }
+}

--- a/test/SecurityTests.cs
+++ b/test/SecurityTests.cs
@@ -1,0 +1,65 @@
+﻿namespace Botwin.Tests
+{
+    using System.Net.Http;
+    using System.Reflection;
+    using System.Security.Claims;
+    using System.Security.Principal;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.TestHost;
+    using Xunit;
+
+    public class SecurityTests
+    {
+        private HttpClient httpClient;
+
+        private void ConfigureServer(bool authedUser = false)
+        {
+            var server = new TestServer(new WebHostBuilder()
+                .ConfigureServices(x => { x.AddBotwin(typeof(TestModule).GetTypeInfo().Assembly); })
+                .Configure(x =>
+                {
+                    if (authedUser)
+                    {
+                        x.Use(async (context, next) =>
+                        {
+                            context.User = new ClaimsPrincipal(new GenericIdentity("AuthedUser"));
+                            await next();
+                        });
+                    }
+                    
+                    x.UseBotwin();
+                })
+            );
+            this.httpClient = server.CreateClient();
+        }
+
+        [Fact]
+        public async Task Should_return_401_when_current_user_not_set()
+        {
+            //Given
+            this.ConfigureServer();
+
+            //When 
+            var response = await this.httpClient.GetAsync("/secure");
+            var body = response.StatusCode;
+
+            //Then
+            Assert.Equal(401, (int)body);
+        }
+
+        [Fact]
+        public async Task Should_hit_route_if_user_authenticated()
+        {
+            //Given
+            this.ConfigureServer(authedUser: true);
+            //When 
+            var response = await this.httpClient.GetAsync("/secure");
+            var body = response.StatusCode;
+
+            //Then
+            Assert.Equal(200, (int)body);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #43 

Whilst looking at this we cannot implement this on a route.  This is because it's a `Func` and the `RequiresAuthentication` just assigns the `Before` hook. Caling that in the route func is too late.  The way Botwin works is it creates handlers that is passed to asp.net core by reading the properties of Before, Routes and After on the module.  At this point Before is null, it's only set when the handler is executed if you put RequiresAuthentication in the handler which obviously is too late.

Only way to change this is to resolve modules per route and try and match the routes to the incoming path, seems like a no go really