### PR TITLE
When registering modules, check if the class is not abstract. This al…

### DIFF
--- a/src/BotwinExtensions.cs
+++ b/src/BotwinExtensions.cs
@@ -161,7 +161,11 @@ namespace Botwin
 
             services.AddRouting();
 
-            var modules = assemblies.SelectMany(x => x.GetTypes().Where(t => typeof(BotwinModule).IsAssignableFrom(t) && t != typeof(BotwinModule)));
+            var modules = assemblies.SelectMany(x => x.GetTypes()
+            .Where(
+                t => !t.IsAbstract &&
+                typeof(BotwinModule).IsAssignableFrom(t) && 
+                t != typeof(BotwinModule)));
             foreach (var module in modules)
             {
                 services.AddTransient(typeof(BotwinModule), module);


### PR DESCRIPTION
…lows to include abstract base classes to generalize code

I added this small change because if I had some module abstract super class, the AddBotwin method was trying to add that to the service collection.