### PR TITLE
Continuing module resolution from request scope (#62)

### DIFF
--- a/src/BotwinModule.cs
+++ b/src/BotwinModule.cs
@@ -38,7 +38,7 @@ namespace Botwin
         /// <param name="basePath">A base path to group routes in your <see cref="BotwinModule"/></param>
         protected BotwinModule(string basePath)
         {
-            this.Routes = new Dictionary<(string verb, string path), RequestDelegate>();
+            this.Routes = new Dictionary<(string verb, string path), RequestDelegate>(RouteComparer.Comparer);
             var cleanPath = this.RemoveStartingSlash(basePath);
             this.basePath = this.RemoveEndingSlash(cleanPath);
         }
@@ -225,6 +225,23 @@ namespace Botwin
             }
 
             return $"{this.basePath}/{path}";
+        }
+
+        /// <summary>
+        /// Case-insensitive comparer for routes.
+        /// </summary>
+        private class RouteComparer : IEqualityComparer<(string verb, string path)>
+        {
+            /// <summary>
+            /// Shared comparer instance.
+            /// </summary>
+            public static RouteComparer Comparer = new RouteComparer();
+
+            public bool Equals((string verb, string path) x, (string verb, string path) y)
+                => StringComparer.OrdinalIgnoreCase.Equals(x.verb, y.verb) && StringComparer.OrdinalIgnoreCase.Equals(x.path, y.path);
+
+            public int GetHashCode((string verb, string path) obj)
+                => (StringComparer.OrdinalIgnoreCase.GetHashCode(obj.verb), StringComparer.OrdinalIgnoreCase.GetHashCode(obj.path)).GetHashCode();
         }
     }
 }

--- a/src/BotwinModule.cs
+++ b/src/BotwinModule.cs
@@ -11,14 +11,14 @@ namespace Botwin
     /// </summary>
     public class BotwinModule
     {
-        public readonly List<(string verb, string path, RequestDelegate handler)> Routes;
+        public readonly Dictionary<(string verb, string path), RequestDelegate> Routes;
 
         private readonly string basePath;
 
         /// <summary>
         /// A handler that can be invoked before the defined route
         /// </summary>
-        public Func<HttpContext, Task<bool>> Before { get; set; } 
+        public Func<HttpContext, Task<bool>> Before { get; set; }
 
         /// <summary>
         /// A handler that can be invoked after the defined route
@@ -38,7 +38,7 @@ namespace Botwin
         /// <param name="basePath">A base path to group routes in your <see cref="BotwinModule"/></param>
         protected BotwinModule(string basePath)
         {
-            this.Routes = new List<(string verb, string path, RequestDelegate handler)>();
+            this.Routes = new Dictionary<(string verb, string path), RequestDelegate>();
             var cleanPath = this.RemoveStartingSlash(basePath);
             this.basePath = this.RemoveEndingSlash(cleanPath);
         }
@@ -63,8 +63,8 @@ namespace Botwin
         {
             path = this.RemoveStartingSlash(path);
             path = this.PrependBasePath(path);
-            this.Routes.Add((HttpMethods.Get, path, handler));
-            this.Routes.Add((HttpMethods.Head, path, handler));
+            this.Routes.Add((HttpMethods.Get, path), handler);
+            this.Routes.Add((HttpMethods.Head, path), handler);
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace Botwin
         {
             path = this.RemoveStartingSlash(path);
             path = this.PrependBasePath(path);
-            this.Routes.Add((HttpMethods.Post, path, handler));
+            this.Routes.Add((HttpMethods.Post, path), handler);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Botwin
         {
             path = this.RemoveStartingSlash(path);
             path = this.PrependBasePath(path);
-            this.Routes.Add((HttpMethods.Delete, path, handler));
+            this.Routes.Add((HttpMethods.Delete, path), handler);
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace Botwin
         {
             path = this.RemoveStartingSlash(path);
             path = this.PrependBasePath(path);
-            this.Routes.Add((HttpMethods.Put, path, handler));
+            this.Routes.Add((HttpMethods.Put, path), handler);
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Botwin
         {
             path = this.RemoveStartingSlash(path);
             path = this.PrependBasePath(path);
-            this.Routes.Add((HttpMethods.Head, path, handler));
+            this.Routes.Add((HttpMethods.Head, path), handler);
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Botwin
         {
             path = this.RemoveStartingSlash(path);
             path = this.PrependBasePath(path);
-            this.Routes.Add((HttpMethods.Patch, path, handler));
+            this.Routes.Add((HttpMethods.Patch, path), handler);
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace Botwin
         {
             path = this.RemoveStartingSlash(path);
             path = this.PrependBasePath(path);
-            this.Routes.Add((HttpMethods.Options, path, handler));
+            this.Routes.Add((HttpMethods.Options, path), handler);
         }
 
         private string RemoveStartingSlash(string path)


### PR DESCRIPTION
This continues the work started by @khellang in #62.

In order to allow for better route lookup, this changes the route list into a dictionary in the module (as already mentioned before in chat). That way, you can now look up a route handler by verb and path instead of having to iterate over the list for a match. In addition, this also has the side effect, that you cannot register multiple handlers for identical routes anymore (maybe this needs some better error handling in the module methods though).

The next step was to avoid creating all those handlers when a route is being activated. The solution is actually pretty simple if you think about what was going on before: All that was happening was that the originally registered route handler was wrapped twice, once with the before and after handler from the module, and then again with that final thing. But we don’t actually need to wrap anything here; instead, we can just combine all those handlers into a single one that does everything—so we basically inline all those wrapping. The result is a single handler that is being constructed *at startup time*, so we are not allocating any handler when the route is later being executed. We just call the correct things in the correct order.

Finally, I refactored that a bit since I was hitting a naming issue myself where I used both the `requestScopedModule` and the original `module` within the handler. To avoid this from happening, I extracted this out in its own method so that you have a clear interface (the method signature) about what will be captured within the created lambda expression.