### PR TITLE
Extract Validate method

### DIFF
--- a/src/ModelBinding/BindExtensions.cs
+++ b/src/ModelBinding/BindExtensions.cs
@@ -19,26 +19,17 @@ namespace Botwin.ModelBinding
         /// </summary>
         /// <param name="request">Current <see cref="HttpRequest"/></param>
         /// <typeparam name="T">Model type</typeparam>
-        /// <returns>Bound model</returns>
+        /// <returns><see cref="ValidationResult"/> and bound model</returns>
         public static (ValidationResult ValidationResult, T Data) BindAndValidate<T>(this HttpRequest request)
         {
-            var data = request.Bind<T>();
-            if (data == null)
+            var model = request.Bind<T>();
+            if (model == null)
             {
-                data = Activator.CreateInstance<T>();
+                model = Activator.CreateInstance<T>();
             }
 
-            var validatorLocator = request.HttpContext.RequestServices.GetService<IValidatorLocator>();
-
-            var validator = validatorLocator.GetValidator<T>();
-
-            if (validator == null)
-            {
-                return (new ValidationResult(new[] { new ValidationFailure(typeof(T).Name, "No validator found") }), default(T));
-            }
-
-            var result = validator.Validate(data);
-            return (result, data);
+            var validationResult = request.Validate(model);            
+            return (validationResult, model);
         }
 
         /// <summary>

--- a/src/ModelBinding/ValidationExtensions.cs
+++ b/src/ModelBinding/ValidationExtensions.cs
@@ -3,9 +3,28 @@ namespace Botwin.ModelBinding
     using System.Collections.Generic;
     using System.Linq;
     using FluentValidation.Results;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.DependencyInjection;
 
     public static class ValidationExtensions
     {
+        /// <summary>
+        /// Performs validation on the specified <paramref name="model"/> instance
+        /// </summary>
+        /// <typeparam name="T">The type of the <paramref name="model"/> that is being validated</typeparam>
+        /// <param name="request">Current <see cref="HttpRequest"/></param>
+        /// <param name="model">The model instance that is being validated</param>
+        /// <returns><see cref="ValidationResult"/></returns>
+        public static ValidationResult Validate<T>(this HttpRequest request, T model)
+        {
+            var validatorLocator = request.HttpContext.RequestServices.GetService<IValidatorLocator>();
+            var validator = validatorLocator.GetValidator<T>();
+
+            return validator == null
+                ? new ValidationResult(new[] { new ValidationFailure(typeof(T).Name, "No validator found") })
+                : validator.Validate(model);
+        }
+
         /// <summary>
         /// Retrieve formatted validation errors
         /// </summary>


### PR DESCRIPTION
Closes #77 

Moved model validation code from within `BindAndValidate` to a separate `Validate` extension method. It is a bit weird having the new method extend `HttpRequest`, which is only needed for service locator, but I left the code as it was.

I modified docs slightly. I didn't add tests since the code is still covered by existing tests for `BindAndValidate`.