### PR TITLE
Make validator lifetimes configurable on a validator-by-validator level

### DIFF
--- a/src/Carter/CarterConfigurator.cs
+++ b/src/Carter/CarterConfigurator.cs
@@ -2,6 +2,7 @@ namespace Carter;
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -16,16 +17,21 @@ public class CarterConfigurator
         this.ModuleTypes = new List<Type>();
         this.ValidatorTypes = new List<Type>();
         this.ResponseNegotiatorTypes = new List<Type>();
-        this.ValidatorServiceLifetime = ServiceLifetime.Singleton;
+        this.DefaultValidatorServiceLifetime = ServiceLifetime.Singleton;
+        this.ValidatorServiceLifetimeFactory = (validatorType) =>
+            validatorType.GetCustomAttribute<ValidatorLifetimeAttribute>()?.Lifetime ??
+            this.DefaultValidatorServiceLifetime;
     }
 
     internal bool ExcludeValidators;
 
     internal bool ExcludeModules;
-        
+
     internal bool ExcludeResponseNegotiators;
 
-    internal ServiceLifetime ValidatorServiceLifetime;
+    internal ServiceLifetime DefaultValidatorServiceLifetime;
+
+    internal Func<Type, ServiceLifetime> ValidatorServiceLifetimeFactory;
 
     internal List<Type> ModuleTypes { get; }
 
@@ -131,7 +137,7 @@ public class CarterConfigurator
         this.ExcludeValidators = true;
         return this;
     }
-        
+
     /// <summary>
     /// Do not register any modules
     /// </summary>
@@ -141,7 +147,7 @@ public class CarterConfigurator
         this.ExcludeModules = true;
         return this;
     }
-        
+
     /// <summary>
     /// Do not register any response negotiators
     /// </summary>
@@ -153,13 +159,24 @@ public class CarterConfigurator
     }
 
     /// <summary>
-    /// Define the lifetime of the validator
+    /// Define the default lifetime of the validator
     /// Default: Singleton
     /// </summary>
     /// <returns></returns>
-    public CarterConfigurator WithValidatorLifetime(ServiceLifetime serviceLifetime)
+    public CarterConfigurator WithDefaultValidatorLifetime(ServiceLifetime serviceLifetime)
     {
-        this.ValidatorServiceLifetime = serviceLifetime;
+        this.DefaultValidatorServiceLifetime = serviceLifetime;
+        this.ValidatorServiceLifetimeFactory = (_) => serviceLifetime;
+        return this;
+    }
+
+    /// <summary>
+    /// Define the validator lifetime factory for custom validator lifetimes based on their type
+    /// </summary>
+    public CarterConfigurator WithValidatorServiceLifetimeFactory(
+        Func<Type, ServiceLifetime> validatorServiceLifetimeFactory)
+    {
+        this.ValidatorServiceLifetimeFactory = validatorServiceLifetimeFactory;
         return this;
     }
 }

--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -175,26 +175,33 @@ public static class CarterExtensions
 
         services.AddSingleton(carterConfigurator);
 
+        ServiceLifetime validatorLocatorLifetime = ServiceLifetime.Singleton;
         foreach (var validator in validators)
         {
+            var validatorServiceLifetime = carterConfigurator.ValidatorServiceLifetimeFactory(validator);
             services.Add(
                 new ServiceDescriptor(
                     serviceType: typeof(IValidator),
                     implementationType: validator,
-                    lifetime: carterConfigurator.ValidatorServiceLifetime));
+                    lifetime: validatorServiceLifetime));
 
             services.Add(
                 new ServiceDescriptor(
                     serviceType: validator,
                     implementationType: validator,
-                    lifetime: carterConfigurator.ValidatorServiceLifetime));
+                    lifetime: validatorServiceLifetime));
+
+            if (validatorServiceLifetime < validatorLocatorLifetime)
+            {
+                validatorLocatorLifetime = validatorServiceLifetime;
+            }
         }
 
         services.Add(
             new ServiceDescriptor(
                 serviceType: typeof(IValidatorLocator),
                 implementationType: typeof(DefaultValidatorLocator),
-                lifetime: carterConfigurator.ValidatorServiceLifetime));
+                lifetime: validatorLocatorLifetime));
 
         foreach (var newModule in newModules)
         {

--- a/src/Carter/ValidatorLifetimeAttirubute.cs
+++ b/src/Carter/ValidatorLifetimeAttirubute.cs
@@ -1,0 +1,10 @@
+namespace Carter;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class ValidatorLifetimeAttribute(ServiceLifetime lifetime) : Attribute
+{
+    public ServiceLifetime Lifetime { get; } = lifetime;
+}


### PR DESCRIPTION
While on a work related project, I came across a DI runtime exception for 'Scoped' lifetime Validators. After doing some digging, I came across [this issue](https://github.com/CarterCommunity/Carter/issues/123) and then [this PR](https://github.com/CarterCommunity/Carter/pull/324) which sets a global lifetime for all validators. This PR aims to add a method to set up custom logic based on type inference on a validator-by-validator level.

### Implementation TLDR:
- Introduces `ValidatorServiceLifetimeFactory` of type `Func<Type, ServiceLifetime>` on `CarterConfigurator`.
- Default factory:
  - Checks for a `[ValidatorLifetime]` attribute on the validator type → uses its `Lifetime`.
  - If no attribute → falls back to `ValidatorServiceLifetime` (global default).
- Users can override the factory via `WithValidatorServiceLifetimeFactory(...)` at startup.
- `CarterExtensions` updated to register validators with lifetimes resolved per type.
- `IValidatorLocator` lifetime is set to the lowest of all registered validator lifetimes.

### Step by step:
On this first draft, it's implemented by the `ValidatorServiceLifetimeFactory` field on `CarterConfigurator` of type `Func<Type, ServiceLifetime>`. This func takes the validator type as an argument and must return a `ServiceLifetime`. It can be passed to the config on startup with the `WithValidatorServiceLifetimeFactory` but it also has a default implementation. By default, it checks for the newly added `ValidatorLifetimeAttribute` on the validator's type and return its `Lifetime` property or the config's `ValidatorServiceLifetime` if there isn't any attribute found.

This all comes together on `CarterExtensions` where the `WireupCarter` validator DI logic is changed to set the lifetime of each validator based on the result of  `ValidatorServiceLifetimeFactory`. As for the `IValidatorLocator` lifetime, that's set to the lowest existing lifetime.

This is by no means ready to merge but more like a POC. I have tested it on my own app and seems to be working so far.



**Note:** Changing `ValidatorServiceLifetime` -> `DefaultValidatorServiceLifetime` is done for readability more than anything. I don't think it should go through since it breaksuser space.