### PR TITLE
Optimize response negotiator selection performance

### DIFF
--- a/src/Carter/Response/ResponseExtensions.cs
+++ b/src/Carter/Response/ResponseExtensions.cs
@@ -26,8 +26,8 @@ public static class ResponseExtensions
     {
         var negotiators = response.HttpContext.RequestServices
             .GetServices<IResponseNegotiator>()
-            .ToList();
-        
+            .ToArray();
+
         var chosenNegotiator = SelectNegotiator(response.HttpContext, negotiators);
 
         return chosenNegotiator.Handle(response.HttpContext.Request, response, model, cancellationToken);
@@ -44,10 +44,10 @@ public static class ResponseExtensions
     {
         var negotiators = response.HttpContext.RequestServices
             .GetServices<IResponseNegotiator>()
-            .ToList();
-
-        var negotiator = negotiators.First(x => x.GetType() == typeof(DefaultJsonResponseNegotiator));
+            .ToArray();
         
+        var negotiator = FindDefaultJsonNegotiator(negotiators);
+
         return negotiator.Handle(response.HttpContext.Request, response, model, cancellationToken);
     }
     
@@ -56,33 +56,67 @@ public static class ResponseExtensions
     /// or defaults to <see cref="DefaultJsonResponseNegotiator"/> if none match.
     /// </summary>
     /// <param name="httpContext">Current <see cref="HttpContext"/></param>
-    /// <param name="negotiators">List of available <see cref="IResponseNegotiator"/> instances</param>
+    /// <param name="negotiators">Array of available <see cref="IResponseNegotiator"/> instances</param>
     /// <returns>The selected <see cref="IResponseNegotiator"/> for the response.</returns>
-    private static IResponseNegotiator SelectNegotiator(HttpContext httpContext, List<IResponseNegotiator> negotiators)
+    private static IResponseNegotiator SelectNegotiator(HttpContext httpContext, IResponseNegotiator[] negotiators)
     {
-        IResponseNegotiator negotiator = null;
+        MediaTypeHeaderValue.TryParseList(httpContext.Request.Headers["Accept"], out var accepts);
 
-        MediaTypeHeaderValue.TryParseList(httpContext.Request.Headers["Accept"], out var accept);
-        if (accept != null)
+        if (accepts?.Count > 0)
         {
-            var ordered = accept.OrderByDescending(x => x.Quality ?? 1);
+            StableSortByQualityDescending(accepts);
 
-            foreach (var acceptHeader in ordered)
+            foreach (var acceptHeader in accepts)
             {
-                negotiator = negotiators.FirstOrDefault(x => x.CanHandle(acceptHeader));
-                if (negotiator != null)
+                foreach (var negotiator in negotiators)
                 {
-                    break;
+                    if (negotiator.CanHandle(acceptHeader))
+                    {
+                        return negotiator;
+                    }
                 }
             }
         }
 
-        if (negotiator == null)
+        return FindDefaultJsonNegotiator(negotiators);
+    }
+
+    /// <summary>
+    /// Finds the registered <see cref="DefaultJsonResponseNegotiator"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no <see cref="DefaultJsonResponseNegotiator"/> is registered.</exception>
+    private static IResponseNegotiator FindDefaultJsonNegotiator(IResponseNegotiator[] negotiators)
+    {
+        foreach (var negotiator in negotiators)
         {
-            negotiator = negotiators.First(x => x.GetType() == typeof(DefaultJsonResponseNegotiator));
+            if (negotiator is DefaultJsonResponseNegotiator)
+            {
+                return negotiator;
+            }
         }
 
-        return negotiator;
+        throw new InvalidOperationException("DefaultJsonResponseNegotiator is not registered.");
+    }
+
+    /// <summary>
+    /// Sorts media types by descending quality while preserving the order of equal-quality values.
+    /// </summary>
+    private static void StableSortByQualityDescending(IList<MediaTypeHeaderValue> accepts)
+    {
+        for (var i = 1; i < accepts.Count; i++)
+        {
+            var current = accepts[i];
+            var currentQuality = current.Quality ?? 1;
+
+            var j = i - 1;
+            while (j >= 0 && (accepts[j].Quality ?? 1) < currentQuality)
+            {
+                accepts[j + 1] = accepts[j];
+                j--;
+            }
+
+            accepts[j + 1] = current;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## What changed

While looking through the response negotiation path, I noticed a few unnecessary allocations and LINQ operations in code that runs on every negotiated response.

This PR improves it by:

- Replacing `List<IResponseNegotiator>` with an array snapshot
- Removing LINQ from the negotiation path (`OrderByDescending`, `First`, `FirstOrDefault`)
- Replacing enumeration-based lookups with simple loops
- Adding a small stable insertion sort for `Accept` header quality ordering
- Extracting the default JSON negotiator lookup into a shared helper

No behavior changes are intended.

---

## Why

The negotiation path runs on every negotiated response, so even small allocations and LINQ overhead add up.

This keeps the existing behavior while reducing allocations and lowering the cost of the hot path.

The insertion sort is intentional here since `Accept` headers are typically very small, making it a simple, allocation-free choice while preserving the ordering of equal quality values.

---

## Benchmark

I benchmarked the original implementation against this version using BenchmarkDotNet.

| Case | Before | After |
|------|--------|-------|
| 1 negotiator | 131 ns | 25 ns |
| 3 negotiators | 129 ns | 27 ns |
| 8 negotiators | 134 ns | 31 ns |

Memory allocations were also reduced significantly:

- **1 negotiator:** 456 B → 32 B
- **3 negotiators:** 472 B → 48 B
- **8 negotiators:** 512 B → 88 B

### Benchmark output

<img width="1287" height="442" alt="BenchmarkDotNet results" src="https://github.com/user-attachments/assets/46bb8574-9991-4aca-91dd-2f613f9c5569" />

The benchmark covers a few representative scenarios:

- **NegotiatorCount** varies the number of registered response negotiators (1, 3 and 8).
- **MultipleAcceptHeaders** compares requests with one accepted media type against requests with multiple accepted media types.
- **Mean** is the average execution time.
- **Allocated** is the memory allocated per operation.

---

## Notes

- No breaking changes
- Existing tests pass
- Focused on reducing overhead in the response negotiation path