### PR TITLE
Fix AddCarter when DependencyContext is unavailable in single-file publish

### DIFF
--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -281,7 +281,9 @@ public static class CarterExtensions
         {
             validators = assemblies.SelectMany(ass => ass.GetTypes())
                 .Where(typeof(IValidator).IsAssignableFrom)
-                .Where(t => !t.GetTypeInfo().IsAbstract);
+                .Where(t =>
+                    !t.GetTypeInfo().IsAbstract &&
+                    !t.ContainsGenericParameters);  // skip open generic validators
 
             carterConfigurator.ValidatorTypes.AddRange(validators);
         }

--- a/src/Carter/DependencyContextAssemblyCatalog.cs
+++ b/src/Carter/DependencyContextAssemblyCatalog.cs
@@ -67,17 +67,29 @@ public class DependencyContextAssemblyCatalog
             {
                 results.Add(overriddenAssembly);
             }
+
+            return results;
         }
-        else
+
+        // DependencyContext is unavailable in single-file published apps.
+        // In that case, return the assemblies already loaded into the AppDomain.
+        if (this.dependencyContext is null)
         {
-            foreach (var library in this.dependencyContext.RuntimeLibraries)
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                if (IsReferencingCarter(library) || IsReferencingFluentValidation(library))
+                results.Add(assembly);
+            }
+
+            return results;
+        }
+
+        foreach (var library in this.dependencyContext.RuntimeLibraries)
+        {
+            if (IsReferencingCarter(library) || IsReferencingFluentValidation(library))
+            {
+                foreach (var assemblyName in library.GetDefaultAssemblyNames(this.dependencyContext))
                 {
-                    foreach (var assemblyName in library.GetDefaultAssemblyNames(this.dependencyContext))
-                    {
-                        results.Add(SafeLoadAssembly(assemblyName));
-                    }
+                    results.Add(SafeLoadAssembly(assemblyName));
                 }
             }
         }


### PR DESCRIPTION
## Summary

`DependencyContext.Load()` returns `null` for single-file published apps (see dotnet/runtime#70438). Carter currently assumes a `DependencyContext` is always available, causing `AddCarter()` to fail during startup. This PR adds a fallback for that scenario while leaving the existing `DependencyContext` path unchanged.

## Changes

- Fall back to `AppDomain.CurrentDomain.GetAssemblies()` when `DependencyContext` is unavailable.
- Preserve the existing discovery behavior when `DependencyContext` is available.
- Skip validators with unbound generic parameters during discovery to avoid registering open generic validator types.

## Testing

### Normal application

Verified that discovery matches the current behavior:

- Assemblies discovered: 3
- Validators discovered: 4
- Modules discovered: 8

### Single-file publish

Published the sample application as a single-file executable and verified that:

- `AddCarter()` no longer throws during startup.
- Modules are discovered and registered correctly.
- Validators are discovered and registered without DI registration failures.
- The application starts successfully.

Observed counts:

- Assemblies discovered: 78 (includes framework assemblies already loaded by the runtime)
- Validators discovered: 3
- Modules discovered: 8

The missing validator belongs to an assembly that isn't loaded by the runtime in the single-file application, so it can't be discovered once `DependencyContext` is unavailable.
 
During testing I found that scanning all loaded assemblies includes FluentValidation's own open generic validator types (for example `InlineValidator<T>`). Without the generic parameter check, DI registration fails with:

```text
System.InvalidOperationException: Cannot instantiate implementation type 'FluentValidation.InlineValidator`1[T]'.
```
 
This PR skips validators that still have unbound generic parameters to avoid that failure.

## Notes

The fallback can only discover assemblies that have already been loaded by the runtime. Assemblies that are never loaded can't be discovered once `DependencyContext` is unavailable. This matches the limitation described in dotnet/runtime#70438.

I intentionally left the fallback unfiltered (it scans all loaded assemblies) because reducing that scan would be an optimization rather than a correctness fix. I'd be happy to explore that separately if it would be useful.

Fixes #383.